### PR TITLE
Remove 'pip install pre-commit', as it's already a dependencie of the package

### DIFF
--- a/centralized_pre_commit_conf/install.py
+++ b/centralized_pre_commit_conf/install.py
@@ -27,10 +27,6 @@ def install_pre_commit(verbose):
     if not Path(".pre-commit-config.yaml").exists():
         warn("No '.pre-commit-config.yaml' found, we can't install pre-commit.")
         sys.exit(ExitCode.PRE_COMMIT_CONF_NOT_FOUND)
-    install_pre_commit_command = ["pip3", "install", "pre-commit==1.14.0"]
-    if verbose:
-        info(f"Launching : {install_pre_commit_command}")
-    subprocess_compat_mode(install_pre_commit_command)
     init_pre_commit = ["pre-commit", "install"]
     if verbose:
         info(f"Launching : {init_pre_commit}")

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     name="centralized-pre-commit-conf",
-    version="0.3.0",
+    version="0.3.2",
     description="Easily install and update centralized pre-commit hooks and their configuration files in decentralized"
     " repositories",
     packages=find_namespace_packages(),


### PR DESCRIPTION
And it's forcing the install of an old version of pre-commit at runtime.