### PR TITLE
ci: modernize Python matrix and bump actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
   linux-tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
@@ -68,6 +69,7 @@ jobs:
   windows-tests:
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
@@ -89,6 +91,7 @@ jobs:
   mac-tests:
     runs-on: macos-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,16 +6,18 @@ on:
 
 env:
   CACHE_VERSION: 4
-  DEFAULT_PYTHON: "3.11"
+  DEFAULT_PYTHON: "3.12"
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
 
 jobs:
   pylint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install dependencies
         run: |
           pip install -e ".[test]"
@@ -27,9 +29,11 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - name: Python ${{ env.DEFAULT_PYTHON }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.DEFAULT_PYTHON }}
       - name: Install dependencies
         run: |
           pip install -e ".[test]"
@@ -44,13 +48,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           pip install -e ".[test]"
@@ -64,13 +69,14 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           pip install -e ".[test]"
@@ -84,13 +90,14 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: |
           pip install -e ".[test]"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
     rev: 7.3.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-bugbear==21.4.3]
+        additional_dependencies: [flake8-bugbear==25.11.29]
   - repo: local
     hooks:
       - id: pylint

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     confuse
     pre-commit>=1.16
     requests
+    typing_extensions
 
 zip_safe = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,16 @@ classifiers =
     Operating System :: OS Independent
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Development Status :: 5 - Production/Stable
 url = https://github.com/Pierre-Sassoulas/centralized-pre-commit-conf
 
 [options]
+python_requires = >=3.10
 packages = find_namespace:
 package_dir =
 


### PR DESCRIPTION
- Test matrix: drop EOL 3.8/3.9, keep 3.10-3.12, add 3.13/3.14 and 3.15 prerelease (allow-prereleases) across linux/windows/mac.
- Bump actions/checkout v2->v4, actions/setup-python v2->v5.
- Wire DEFAULT_PYTHON (3.12) into pylint/coverage jobs.
- setup.cfg: classifiers 3.10-3.14, add python_requires >=3.10.