### PR TITLE
Authenticate to private repositories (closes #33)

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,7 @@ multi_line_output=3
 line_length=88
 force_grid_wrap = 0
 use_parentheses = True
+include_trailing_comma = True
 float_to_top=true
 ensure_newline_before_comments = True
 known_third_party=

--- a/README.md
+++ b/README.md
@@ -99,6 +99,72 @@ All configuration files already existed.
 Next commit supposing the `.pre-commit-config.yaml` is done correctly your modified
 files we be linted with the centralized configuration.
 
+### Private repositories (authentication)
+
+If your configuration lives in a private repository, an unauthenticated request is
+redirected to a login page and the HTML of that page would be downloaded instead of your
+configuration file. `pre-commit-conf` detects that redirection and reports a failed
+download asking you to provide a token.
+
+To authenticate, provide a token. The token is sent as the `PRIVATE-TOKEN` header on
+every request.
+
+You do **not** need a broad token: `pre-commit-conf` only reads from the single
+repository that holds your centralized configuration, so grant the least privilege that
+works. On GitLab, prefer a
+[Project Access Token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html)
+created on that one configuration repository, with only the `read_repository` scope. A
+Group Access Token (if the configuration repository may move within a group) or a
+Personal Access Token also work, but a Personal Access Token can read every repository
+your account can access — if it leaks, everything leaks — so avoid it unless necessary.
+
+On GitLab, set `provider: gitlab`. The `read_repository` scope authenticates against the
+[Repository Files API](https://docs.gitlab.com/ee/api/repository_files.html), not the
+`/-/raw/` web endpoint (which only accepts a browser session), so `pre-commit-conf`
+fetches each file through the API. Point `repository` at the project's web URL — the
+host and project path are enough, the API URL is built for you:
+
+```yaml
+configuration_files:
+  - ".pylintrc"
+  - ".pre-commit-config.yaml"
+repository: https://gitlab.mycompany.net/admin-sys/internal-pre-commit-conf
+provider: gitlab
+branch: master
+path: ""
+```
+
+Then supply the token using one of the following (precedence: CLI > config > env var — a
+`token` set in a config file shadows the environment variable):
+
+1. **Environment variable (recommended)** — set it once, used on every run, never stored
+   in a committed file:
+
+   ```bash
+   export PRE_COMMIT_CONF_TOKEN="glpat-xxxxxxxxxxxxxxxxxxxx"
+   pre-commit-conf
+   ```
+
+2. **Config file** — convenient but keep the file out of version control, it contains a
+   secret:
+
+   ```yaml
+   token: "glpat-xxxxxxxxxxxxxxxxxxxx"
+   ```
+
+3. **Command line** — avoid for real tokens, it leaks into your shell history and the
+   process list:
+
+   ```bash
+   pre-commit-conf --token "glpat-xxxxxxxxxxxxxxxxxxxx"
+   ```
+
+In CI, store the token as a masked/protected variable named `PRE_COMMIT_CONF_TOKEN`.
+
+Setup is a one-time thing: configure the repository once and keep the token available
+(in your shell profile or CI secrets) so every run authenticates automatically. The only
+recurring task is renewing the token when it expires.
+
 ## Development / contribution
 
 ```bash

--- a/centralized_pre_commit_conf/config_default.yaml
+++ b/centralized_pre_commit_conf/config_default.yaml
@@ -5,6 +5,8 @@ configuration_files:
   - ".pylintrc"
 repository: https://raw.githubusercontent.com/Pierre-Sassoulas/centralized-pre-commit-conf
 branch: master
+token: ""
+provider: "raw"
 path: "centralized_pre_commit_conf/static"
 dependencies: ["black==19.3b0", "isort==4.3.15", "pylint", "flake8"]
 gitignore_info_text:

--- a/centralized_pre_commit_conf/constants.py
+++ b/centralized_pre_commit_conf/constants.py
@@ -2,6 +2,12 @@ import enum
 
 APPLICATION_NAME = "pre-commit-conf"
 TIMEOUT = 10.0
+# Token can also be supplied via this environment variable to avoid storing
+# secrets in the config file or shell history.
+TOKEN_ENV_VAR = "PRE_COMMIT_CONF_TOKEN"
+# Supported ways to build download URLs. 'raw' templates the URL directly
+# (GitHub raw and similar); 'gitlab' uses the Repository Files API.
+PROVIDERS = ("raw", "gitlab")
 
 
 class ExitCode(enum.Enum):

--- a/centralized_pre_commit_conf/download_configuration.py
+++ b/centralized_pre_commit_conf/download_configuration.py
@@ -6,8 +6,8 @@ import confuse
 import requests
 from urllib3.exceptions import InsecureRequestWarning
 
-from centralized_pre_commit_conf.constants import TIMEOUT
-from centralized_pre_commit_conf.parse_args import get_url_from_args
+from centralized_pre_commit_conf.constants import TIMEOUT, TOKEN_ENV_VAR
+from centralized_pre_commit_conf.parse_args import build_config_file_url
 from centralized_pre_commit_conf.prints import error, info, success, warn
 
 
@@ -31,25 +31,29 @@ class Result:
 def download_configuration(config: confuse.Configuration) -> None:
     results = {}
     config_files = config["configuration_files"].get(list)
-    url = get_url_from_args(
-        config["repository"].get(str),
-        config["branch"].get(str),
-        config["path"].get(str),
-    )
+    provider = config["provider"].get(str)
+    repository = config["repository"].get(str)
+    branch = config["branch"].get(str)
+    config_path = config["path"].get(str)
     insecure = config["insecure"].get(bool)
     verbose = config["verbose"].get(bool)
+    token = config["token"].get(str) or os.environ.get(TOKEN_ENV_VAR, "")
+    if token and verbose:
+        info("Authenticating with the provided token.")
     for config_file in config_files:
         result = Result()
-        config_file_url = f"{url}/{config_file}"
+        config_file_url = build_config_file_url(
+            provider, repository, branch, config_path, config_file
+        )
         if verbose:
             info(f"Downloading '{config_file}' from '{config_file_url}'")
-        request_result = recover_new_content(config_file_url, insecure)
-        result.downloaded = request_result.status_code == 200
+        request_result = recover_new_content(config_file_url, token, insecure)
+        result.downloaded = is_successful_download(request_result)
         if not result.downloaded:
             result.failed_download = request_result
             results[config_file] = result
             continue
-        path = Path(config_file_url)
+        path = Path(config_file)
         old_content = None
         file_already_exists = os.path.exists(config_file)
         if file_already_exists:
@@ -110,16 +114,44 @@ def display_results(results: dict[str, Result]) -> None:
         success(f"🎉✨ {replaced} configuration file{plural} updated. ✨🎉")
 
 
-def recover_new_content(config_file_url: str, insecure: bool) -> requests.Response:
+def recover_new_content(
+    config_file_url: str, token: str, insecure: bool
+) -> requests.Response:
+    headers = _authentication_headers(token)
     with warnings.catch_warnings(record=True) as messages:
-        if insecure:
-            result = requests.get(config_file_url, verify=False, timeout=TIMEOUT)
-        else:
-            result = requests.get(config_file_url, timeout=TIMEOUT)
+        result = requests.get(
+            config_file_url,
+            verify=not insecure,
+            timeout=TIMEOUT,
+            headers=headers,
+        )
         for msg in messages:
             if not insecure or msg.category is not InsecureRequestWarning:
                 warn(msg.message)
     return result
+
+
+def _authentication_headers(token: str) -> dict[str, str]:
+    """GitLab uses the 'PRIVATE-TOKEN' header for private repositories."""
+    if token:
+        return {"PRIVATE-TOKEN": token}
+    return {}
+
+
+def is_successful_download(request_result: requests.Response) -> bool:
+    """A real raw file is served directly with a 200.
+
+    When authentication is missing or invalid, private hosts (e.g. GitLab)
+    redirect to a login page that also returns a 200 but with HTML content.
+    A non-empty redirection history flags that case as a failed download.
+    """
+    if request_result.history:
+        warn(
+            f"'{request_result.url}' was redirected (login page?). "
+            "Provide a token to authenticate to a private repository."
+        )
+        return False
+    return request_result.status_code == 200
 
 
 def write_new_content(path: Path, request_result: requests.Response) -> None:

--- a/centralized_pre_commit_conf/parse_args.py
+++ b/centralized_pre_commit_conf/parse_args.py
@@ -1,6 +1,9 @@
 import argparse
+from urllib.parse import quote, urlsplit
 
 import confuse
+
+from centralized_pre_commit_conf.constants import PROVIDERS, TOKEN_ENV_VAR
 
 
 def get_url_from_args(url: str, branch: str, path: str) -> str:
@@ -18,6 +21,32 @@ def get_url_from_args(url: str, branch: str, path: str) -> str:
     return f"{url}"
 
 
+def build_config_file_url(
+    provider: str, repository: str, branch: str, path: str, config_file: str
+) -> str:
+    """Build the download URL for a single configuration file.
+
+    The default 'raw' provider templates the URL directly (e.g. GitHub raw).
+    The 'gitlab' provider uses the Repository Files API, the only endpoint that
+    a 'read_repository' token can authenticate to with the 'PRIVATE-TOKEN'
+    header (the '/-/raw/' web endpoint requires a browser session).
+    """
+    if provider == "gitlab":
+        return _gitlab_file_url(repository, branch, path, config_file)
+    return f"{get_url_from_args(repository, branch, path)}/{config_file}"
+
+
+def _gitlab_file_url(repository: str, branch: str, path: str, config_file: str) -> str:
+    split = urlsplit(repository.rstrip("/"))
+    host = f"{split.scheme}://{split.netloc}"
+    project = split.path.strip("/")
+    file_path = "/".join(part for part in (path.strip("/"), config_file) if part)
+    return (
+        f"{host}/api/v4/projects/{quote(project, safe='')}"
+        f"/repository/files/{quote(file_path, safe='')}/raw?ref={branch}"
+    )
+
+
 def parse_args(config: confuse.Configuration) -> confuse.Configuration:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -28,6 +57,26 @@ def parse_args(config: confuse.Configuration) -> confuse.Configuration:
     )
     parser.add_argument(
         "-b", "--branch", default=config["branch"].get("str"), help="Git branch"
+    )
+    parser.add_argument(
+        "-t",
+        "--token",
+        default=config["token"].get(str),
+        help=(
+            "Token to authenticate to a private repository "
+            "(GitLab 'PRIVATE-TOKEN'). Can also be set via the "
+            f"{TOKEN_ENV_VAR} environment variable."
+        ),
+    )
+    parser.add_argument(
+        "--provider",
+        choices=PROVIDERS,
+        default=config["provider"].get(str),
+        help=(
+            "How to build download URLs. 'raw' templates the URL directly "
+            "(e.g. GitHub raw); 'gitlab' uses the Repository Files API so a "
+            "'read_repository' token can authenticate to a private project."
+        ),
     )
     parser.add_argument(
         "-p",

--- a/centralized_pre_commit_conf/parse_args.py
+++ b/centralized_pre_commit_conf/parse_args.py
@@ -56,7 +56,7 @@ def parse_args(config: confuse.Configuration) -> confuse.Configuration:
         help="Git repository URL",
     )
     parser.add_argument(
-        "-b", "--branch", default=config["branch"].get("str"), help="Git branch"
+        "-b", "--branch", default=config["branch"].get(str), help="Git branch"
     )
     parser.add_argument(
         "-t",

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,0 +1,36 @@
+import requests
+
+from centralized_pre_commit_conf.download_configuration import (
+    _authentication_headers,
+    is_successful_download,
+)
+
+
+class TestAuthenticationHeaders:
+    def test_no_token(self) -> None:
+        assert _authentication_headers("") == {}
+
+    def test_with_token(self) -> None:
+        assert _authentication_headers("secret") == {"PRIVATE-TOKEN": "secret"}
+
+
+class TestIsSuccessfulDownload:
+    def _response(
+        self, status_code: int, history: list[requests.Response]
+    ) -> requests.Response:
+        response = requests.Response()
+        response.status_code = status_code
+        response.history = history
+        response.url = "http://a.net/.flake8"
+        return response
+
+    def test_direct_200_is_success(self) -> None:
+        assert is_successful_download(self._response(200, [])) is True
+
+    def test_non_200_is_failure(self) -> None:
+        assert is_successful_download(self._response(404, [])) is False
+
+    def test_redirected_200_is_failure(self) -> None:
+        # Login page redirection: 200 but content is HTML, not the raw file.
+        redirect = self._response(302, [])
+        assert is_successful_download(self._response(200, [redirect])) is False

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -8,7 +8,7 @@ from centralized_pre_commit_conf.download_configuration import (
 
 class TestAuthenticationHeaders:
     def test_no_token(self) -> None:
-        assert _authentication_headers("") == {}
+        assert not _authentication_headers("")
 
     def test_with_token(self) -> None:
         assert _authentication_headers("secret") == {"PRIVATE-TOKEN": "secret"}

--- a/tests/test_build_config_file_url.py
+++ b/tests/test_build_config_file_url.py
@@ -1,0 +1,49 @@
+from centralized_pre_commit_conf.parse_args import build_config_file_url
+
+
+class TestBuildConfigFileUrl:
+    def test_raw_provider_templates_url(self) -> None:
+        assert (
+            build_config_file_url(
+                "raw",
+                "https://raw.githubusercontent.com/owner/repo",
+                "master",
+                "static",
+                ".flake8",
+            )
+            == "https://raw.githubusercontent.com/owner/repo/master/static/.flake8"
+        )
+
+    def test_raw_provider_without_path(self) -> None:
+        assert (
+            build_config_file_url(
+                "raw", "https://a.net/owner/repo", "main", "", ".pylintrc"
+            )
+            == "https://a.net/owner/repo/main/.pylintrc"
+        )
+
+    def test_gitlab_provider_uses_files_api(self) -> None:
+        assert build_config_file_url(
+            "gitlab",
+            "https://gitlab.e-lum.io/admin-sys/internal-pre-commit-conf",
+            "master",
+            "",
+            ".pre-commit-config.yaml",
+        ) == (
+            "https://gitlab.e-lum.io/api/v4/projects/"
+            "admin-sys%2Finternal-pre-commit-conf/repository/files/"
+            ".pre-commit-config.yaml/raw?ref=master"
+        )
+
+    def test_gitlab_provider_encodes_path_and_trailing_slash(self) -> None:
+        assert build_config_file_url(
+            "gitlab",
+            "https://gitlab.e-lum.io/group/sub/project/",
+            "main",
+            "configs/lint",
+            ".flake8",
+        ) == (
+            "https://gitlab.e-lum.io/api/v4/projects/"
+            "group%2Fsub%2Fproject/repository/files/"
+            "configs%2Flint%2F.flake8/raw?ref=main"
+        )

--- a/tests/test_build_config_file_url.py
+++ b/tests/test_build_config_file_url.py
@@ -2,7 +2,7 @@ from centralized_pre_commit_conf.parse_args import build_config_file_url
 
 
 class TestBuildConfigFileUrl:
-    def test_raw_provider_templates_url(self) -> None:
+    def test_raw_url(self) -> None:
         assert (
             build_config_file_url(
                 "raw",
@@ -14,7 +14,7 @@ class TestBuildConfigFileUrl:
             == "https://raw.githubusercontent.com/owner/repo/master/static/.flake8"
         )
 
-    def test_raw_provider_without_path(self) -> None:
+    def test_raw_url_without_path(self) -> None:
         assert (
             build_config_file_url(
                 "raw", "https://a.net/owner/repo", "main", "", ".pylintrc"
@@ -22,7 +22,7 @@ class TestBuildConfigFileUrl:
             == "https://a.net/owner/repo/main/.pylintrc"
         )
 
-    def test_gitlab_provider_uses_files_api(self) -> None:
+    def test_gitlab_files_api_url(self) -> None:
         assert build_config_file_url(
             "gitlab",
             "https://gitlab.e-lum.io/admin-sys/internal-pre-commit-conf",
@@ -35,7 +35,7 @@ class TestBuildConfigFileUrl:
             ".pre-commit-config.yaml/raw?ref=master"
         )
 
-    def test_gitlab_provider_encodes_path_and_trailing_slash(self) -> None:
+    def test_gitlab_url_encoding(self) -> None:
         assert build_config_file_url(
             "gitlab",
             "https://gitlab.e-lum.io/group/sub/project/",


### PR DESCRIPTION
Closes #33.

## Problem

When the configuration lives in a private repository, an unauthenticated request follows a redirect to a login page, so the HTML of that login page is downloaded and written as the configuration file.

## Changes

- **Token auth** — sent as the GitLab `PRIVATE-TOKEN` header. Supplied via `--token`, the `token` config option, or the `PRE_COMMIT_CONF_TOKEN` environment variable (precedence: CLI > config > env).
- **`provider` option** — default `raw` keeps templating the URL directly (GitHub raw and similar). `gitlab` uses the [Repository Files API](https://docs.gitlab.com/ee/api/repository_files.html), the only endpoint a `read_repository` token can authenticate to with the `PRIVATE-TOKEN` header (the `/-/raw/` web endpoint requires a browser session).
- **Redirect guard** — a download that went through a redirect is treated as failed, so a login page is never saved as a configuration file.
- **Filename fix** — derive the local file name from the configured file name instead of the download URL (required now that a GitLab URL ends with `/raw?ref=...`).
- Docs: new "Private repositories (authentication)" README section, with least-privilege token guidance.

## Tests

- New unit tests for `build_config_file_url` (raw + gitlab) and for the auth header / redirect-detection helpers.
- Verified end-to-end against a real private GitLab repo: valid `read_repository` token downloads correctly; invalid token returns a clean HTTP 401 with no HTML written.