### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 authors = [{name = "Pierre Sassoulas", email = "pierre.sassoulas@gmail.com"}]
 name = "centralized-pre-commit-conf"
-version = "0.6.1"
+version = "0.7.0"
 description = "Easily install and update centralized pre-commit hooks and their configuration files in decentralized repositories"
 classifiers = [
     "Operating System :: OS Independent",


### PR DESCRIPTION
Bumps the version `0.6.1` → `0.7.0` for the upcoming release.

## ⚠️ Release workflow still needs fixing

The migration to `pyproject.toml` (#93) deleted `setup.py`, but `.github/workflows/release.yaml` still runs `python setup.py sdist bdist_wheel` — which will **fail** on release. It must be switched to `python -m build` before tagging `v0.7.0`.

I could not push that workflow change (the local token lacks the `workflow` OAuth scope). To apply it, either:
- run `gh auth refresh -s workflow` and let me push it, or
- edit `release.yaml` via the GitHub web UI (copy from `django-zxcvbn-password-validator`).

## Release steps

1. Merge #96 (gitignore cache feature) and this PR into `main`.
2. Fix `release.yaml` → `python -m build`.
3. Create tag + GitHub Release `v0.7.0` → publishes to PyPI.